### PR TITLE
Change how messages are broadcast

### DIFF
--- a/bminterface.py
+++ b/bminterface.py
@@ -44,6 +44,9 @@ def _sendBroadcast(fromAddress, subject, body):
       return 0
       
 def _stripAddress(address):
+    if 'broadcast' in address.lower():
+      return 'broadcast'
+
     orig = address
     alphabet = '123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ'
     retstring = ''
@@ -64,7 +67,7 @@ def send(toAddress, fromAddress, subject, body):
     fromAddress = _stripAddress(fromAddress)
     subject = subject.encode('base64')
     body = body.encode('base64')
-    if toAddress == fromAddress:
+    if toAddress == 'broadcast':
       return _sendBroadcast(fromAddress, subject, body)
     else:
       return _sendMessage(toAddress, fromAddress, subject, body)


### PR DESCRIPTION
Massages with the same to and from address are sent from the address to the same address, instead of being broadcast. To send a broadcast the user includes "broadcast" anywhere in the to address.

This allows users to use the send to chan method in compliance with the new chan support in PyBitmessage.
